### PR TITLE
Add Render static site configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Zeller1 Static Site
+
+This repository contains a static HTML site.
+
+## Deploying to Render
+
+1. Log in to [Render](https://render.com) and create a new **Static Site**.
+2. Connect this repository and use the following settings:
+   - **Build Command:** leave blank
+   - **Publish Directory:** `.`
+3. Save the site and Render will deploy the contents of the repository so that `index.html` is served at the root.
+
+The `render.yaml` file in this repo contains the same configuration and allows Render to auto-detect the static site.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: static_site
+    name: zeller1-static-site
+    env: static
+    staticPublishPath: .
+    buildCommand: ""


### PR DESCRIPTION
## Summary
- add `render.yaml` so Render can deploy the project as a static site
- document deployment steps in `README.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68944df5beec832ca07db13dd789b129